### PR TITLE
Session middleware rewrite to delay/await registering routes etc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,8 @@
 {
-  "presets": [
-    "es2015"
-  ],
   "plugins": [
-    "transform-function-bind"
+    "transform-async-to-generator",
+    "transform-function-bind",
+    "transform-object-rest-spread",
+    "transform-es2015-modules-commonjs"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "compression": "^1.4.3",
     "express": "^4.14.0",
     "express-session": "^1.14.1",
-    "nxus-core": "^4.0.0-0",
+    "nxus-core": "^4.0.0",
     "session-file-store": "^0.2.1",
     "underscore": "^1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-router",
-  "version": "4.0.0-3",
+  "version": "4.0.0",
   "description": "An express-based router for Nxus",
   "main": "lib",
   "scripts": {
@@ -20,6 +20,7 @@
   "author": "info@nxusapp.com",
   "license": "MIT",
   "dependencies": {
+    "babel-preset-env": "^1.6.0",
     "bluebird": "^3.0.5",
     "body-parser": "^1.10.1",
     "compression": "^1.4.3",
@@ -36,6 +37,8 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
+    "babel-register": "^6.9.0",
+    "babel-plugin-transform-async-to-generator": "^6.16.0",
     "babel-plugin-transform-function-bind": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "chai": "^3.5.0",

--- a/src/modules/router-sessions-file/index.js
+++ b/src/modules/router-sessions-file/index.js
@@ -1,3 +1,0 @@
-// TODO: solve module loading so that this can register before the first middleware needs to be set on router in RouterSessions.
-
-export default () => {}

--- a/src/modules/router-sessions/index.js
+++ b/src/modules/router-sessions/index.js
@@ -19,14 +19,13 @@ class RouterSessions extends NxusModule {
   constructor(app) {
     super(app)
 
-    let settings = this.config
-    // TODO move this to router-sessions-file - but need access EARLY
-    settings.store = new FileStore({path: './.tmp/sessions'})
-    settings.logFn = application.log.debug
-
-    router.default('middleware', expressSession(settings))
+    router.default().sessionMiddleware(this._sessionName(), ::this._createSession )
   }
 
+  _sessionName() {
+    return 'file-store-session'
+  }
+  
   _defaultConfig() {
     return {
       cookie: {
@@ -37,6 +36,17 @@ class RouterSessions extends NxusModule {
       resave: true,
       saveUninitialized: true,
     }
+  }
+
+  async _createSession() {
+    let settings = this.config
+    settings.logFn = application.log.debug
+    settings.store = await this._createStore(settings)
+    return expressSession(settings)
+  }
+
+  _createStore() {
+    return new FileStore({path: './.tmp/sessions'})
   }
 
 };

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -34,7 +34,7 @@ describe("Router", () => {
     })
 
     it("should be instantiated", () => {
-      router = new Router(app);
+      router = new Router();
       router.should.not.be.null;
     });
   });
@@ -49,7 +49,13 @@ describe("Router", () => {
 
     it("should have port after load", () => {
       router.should.have.property('port');
-      router.should.have.property('routeTable');
+      router.should.have.property('_routeTable');
+      router.should.have.property('registered', false);
+    });
+
+    it("should have default config after load", () => {
+      router.config.should.have.property('staticRoutesInSession', false);
+      router.config.should.have.property('sessionStoreName', 'file-store-session');
     });
   });
 


### PR DESCRIPTION
Adds a new method for registering a named session middleware handler, and delays registering middleware, staticRoutes, and routes until launch so that session middleware can return a promise.

Adds config for selecting which available session middleware to use, and whether to include staticRoutes within sessions or not. Defaults to not, so by default closes #15 and supports using alternate session as in `nxus-storage` `waterline-session` and so closes #14 when not using `resave/saveUninitialized`.